### PR TITLE
feat: adds -- and without -- optional arguments

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,0 +1,9 @@
+package vanda
+
+type ErrInvalidPattern struct {
+	Message string
+}
+
+func (n *ErrInvalidPattern) Error() string {
+	return n.Message
+}

--- a/error.go
+++ b/error.go
@@ -1,9 +1,13 @@
 package vanda
 
-type ErrInvalidPattern struct {
+type ArgumentParsingError struct {
 	Message string
 }
 
-func (n *ErrInvalidPattern) Error() string {
+type ArgumentCastingError struct {
+	Message string
+}
+
+func (n *ArgumentParsingError) Error() string {
 	return n.Message
 }

--- a/example/main.go
+++ b/example/main.go
@@ -7,11 +7,9 @@ import (
 
 func main() {
 	patterns := []string{
-		"<start> [integration:string] [key:string] {=from:string} {=to:string}",
-		"<nmap> [ip:string] {sV:bool} {=oN:string} {=minrate:int}",
+		"<subcommand> [requiredone:string] [requiredtwo:string] {=optionalone:string} {=optionaltwo:string}",
 	}
-	argv := []string{"start", "jira", "knox", "-from", "1000", "-to", "1030"}
-	// argv := []string{"nmap", "10.10.10.10", "-sV", "-oN", "scan.txt", "-minrate", "1000"}
+	argv := []string{"subcommand", "requiredparam1", "requiredparam2", "-optionalone", "10", "-optionaltwo", "20"}
 
 	parser, err := vanda.NewParser(patterns)
 	if err != nil {

--- a/example/main.go
+++ b/example/main.go
@@ -7,9 +7,9 @@ import (
 
 func main() {
 	patterns := []string{
-		"<subcommand> [requiredone:string] [requiredtwo:string] {=optionalone:string} {=optionaltwo:string}",
+		"<subcommand> [requiredone:string] [requiredtwo:string] {==optionalone:string} {=optionaltwo:string}",
 	}
-	argv := []string{"subcommand", "requiredparam1", "requiredparam2", "-optionalone", "10", "-optionaltwo", "20"}
+	argv := []string{"subcommand", "requiredparam1", "requiredparam2", "--optionalone", "10", "optionaltwo", "20"}
 
 	parser, err := vanda.NewParser(patterns)
 	if err != nil {

--- a/pattern.go
+++ b/pattern.go
@@ -11,15 +11,25 @@ func ParsePattern(pattern string) (*CommandPattern, error) {
 		return nil, fmt.Errorf("empty pattern")
 	}
 
-	// first part must be <command>
+	// Process subcommands
 	if !strings.HasPrefix(parts[0], "<") || !strings.HasSuffix(parts[0], ">") {
+		//TODO: when no subcommands are defined, just follow a single pattern
 		return nil, fmt.Errorf("pattern must start with <command>")
 	}
+
 	cmdName := strings.Trim(parts[0], "<>")
 
 	var args []ArgPattern
 
-	for _, part := range parts[1:] {
+	var flags []string
+
+	if cmdName != "" {
+		flags = parts[1:]
+	} else {
+		flags = parts
+	}
+
+	for _, part := range flags {
 		switch {
 		// required argument
 		case strings.HasPrefix(part, "[") && strings.HasSuffix(part, "]"):
@@ -38,30 +48,27 @@ func ParsePattern(pattern string) (*CommandPattern, error) {
 		case strings.HasPrefix(part, "{") && strings.HasSuffix(part, "}"):
 			content := strings.Trim(part, "{}")
 
+			var nameType []string
 			// flag with value: {=flag:type}
-			if strings.HasPrefix(content, "=") {
-				content = strings.TrimPrefix(content, "=")
-				nameType := strings.Split(content, ":")
+			if cntn, ok := strings.CutPrefix(content, "="); ok {
+				nameType = strings.Split(cntn, ":")
 				if len(nameType) != 2 {
 					return nil, fmt.Errorf("invalid flag with value: %s", part)
 				}
-				args = append(args, ArgPattern{
-					Name: nameType[0],
-					Flag: "-" + nameType[0],
-					Type: ArgType(nameType[1]),
-				})
 			} else {
 				// boolean flag: {flag:bool}
-				nameType := strings.Split(content, ":")
+				nameType = strings.Split(cntn, ":")
 				if len(nameType) != 2 {
 					return nil, fmt.Errorf("invalid flag: %s", part)
 				}
-				args = append(args, ArgPattern{
-					Name: nameType[0],
-					Flag: "-" + nameType[0],
-					Type: ArgType(nameType[1]),
-				})
 			}
+
+			args = append(args, ArgPattern{
+				Name: nameType[0],
+				Flag: "-" + nameType[0],
+				Type: ArgType(nameType[1]),
+			})
+
 		}
 	}
 

--- a/pattern.go
+++ b/pattern.go
@@ -8,13 +8,17 @@ import (
 func ParsePattern(pattern string) (*CommandPattern, error) {
 	parts := strings.Fields(pattern)
 	if len(parts) == 0 {
-		return nil, fmt.Errorf("empty pattern")
+		return nil, &ArgumentParsingError{
+			"Empty Pattern",
+		}
 	}
 
 	// Process subcommands
 	if !strings.HasPrefix(parts[0], "<") || !strings.HasSuffix(parts[0], ">") {
 		//TODO: when no subcommands are defined, just follow a single pattern
-		return nil, fmt.Errorf("pattern must start with <command>")
+		return nil, &ArgumentParsingError{
+			"Pattern must start with <command>",
+		}
 	}
 
 	cmdName := strings.Trim(parts[0], "<>")
@@ -36,7 +40,9 @@ func ParsePattern(pattern string) (*CommandPattern, error) {
 			content := strings.Trim(part, "[]")
 			nameType := strings.Split(content, ":")
 			if len(nameType) != 2 {
-				return nil, fmt.Errorf("invalid required argument: %s", part)
+				return nil, &ArgumentParsingError{
+					fmt.Sprintf("Invalid required argument: %s", part),
+				}
 			}
 			args = append(args, ArgPattern{
 				Name:     nameType[0],
@@ -53,24 +59,28 @@ func ParsePattern(pattern string) (*CommandPattern, error) {
 			if cntn, ok := strings.CutPrefix(content, "="); ok {
 				nameType = strings.Split(cntn, ":")
 				if len(nameType) != 2 {
-					return nil, fmt.Errorf("invalid flag with value: %s", part)
+					return nil, &ArgumentParsingError{
+						fmt.Sprintf("Invalid flag: %s", part),
+					}
 				}
-			} else {
-				// boolean flag: {flag:bool}
-				nameType = strings.Split(cntn, ":")
-				if len(nameType) != 2 {
-					return nil, fmt.Errorf("invalid flag: %s", part)
+				if cntn1, ok1 := strings.CutPrefix(nameType[0], "="); ok1 {
+					println("with -- ", fmt.Sprintf("--%s", cntn1))
+					args = append(args, ArgPattern{
+						Name: cntn1,
+						Flag: fmt.Sprintf("--%s", cntn1),
+						Type: ArgType(nameType[1]),
+					})
+				} else {
+					println("without --", nameType[0])
+					args = append(args, ArgPattern{
+						Name: nameType[0],
+						Flag: nameType[0],
+						Type: ArgType(nameType[1]),
+					})
 				}
 			}
-
-			args = append(args, ArgPattern{
-				Name: nameType[0],
-				Flag: "-" + nameType[0],
-				Type: ArgType(nameType[1]),
-			})
-
 		}
-	}
 
+	}
 	return &CommandPattern{Name: cmdName, Args: args}, nil
 }

--- a/vanda.go
+++ b/vanda.go
@@ -48,9 +48,11 @@ func NewParser(patterns []string) (*Parser, error) {
 }
 
 // MatchAndParse picks the correct command pattern based on argv[0] and parses the rest
-func (p *Parser) MatchAndParse(argv []string) (string, map[string]interface{}, error) {
+func (p *Parser) MatchAndParse(argv []string) (string, map[string]any, error) {
 	if len(argv) == 0 {
-		return "", nil, fmt.Errorf("no command provided")
+		return "", nil, &ArgumentParsingError{
+			"no command provided",
+		}
 	}
 
 	cmdArg := argv[0]
@@ -62,17 +64,21 @@ func (p *Parser) MatchAndParse(argv []string) (string, map[string]interface{}, e
 		}
 	}
 	if selected == nil {
-		return "", nil, fmt.Errorf("unknown command: %s", cmdArg)
+		return "", nil, &ArgumentParsingError{
+			fmt.Sprintf("unknown command: %s", cmdArg),
+		}
 	}
 
 	// parse the remaining args
-	result := make(map[string]interface{})
+	result := make(map[string]any)
 	rest := argv[1:]
 
 	for _, pat := range selected.Args {
 		if pat.Required {
 			if len(rest) == 0 {
-				return "", nil, fmt.Errorf("missing required argument: %s", pat.Name)
+				return "", nil, &ArgumentParsingError{
+					fmt.Sprintf("missing required argument: %s", pat.Name),
+				}
 			}
 			val, err := castValue(rest[0], pat.Type)
 			if err != nil {
@@ -90,15 +96,15 @@ func (p *Parser) MatchAndParse(argv []string) (string, map[string]interface{}, e
 				}
 			} else {
 				for i := 0; i < len(rest); i++ {
-					if strings.HasPrefix(rest[i], "-"+pat.Name) {
-						if rest[i] == "-"+pat.Name && i+1 < len(rest) {
+					if strings.HasPrefix(rest[i], pat.Flag) {
+						if rest[i] == pat.Flag && i+1 < len(rest) {
 							val, err := castValue(rest[i+1], pat.Type)
 							if err != nil {
 								return "", nil, err
 							}
 							result[pat.Name] = val
 						} else {
-							val, err := castValue(strings.TrimPrefix(rest[i], "-"+pat.Name), pat.Type)
+							val, err := castValue(strings.TrimPrefix(rest[i], pat.Flag), pat.Type)
 							if err != nil {
 								return "", nil, err
 							}
@@ -113,7 +119,7 @@ func (p *Parser) MatchAndParse(argv []string) (string, map[string]interface{}, e
 	return selected.Name, result, nil
 }
 
-func castValue(s string, t ArgType) (interface{}, error) {
+func castValue(s string, t ArgType) (any, error) {
 	switch t {
 	case String:
 		return s, nil
@@ -122,6 +128,8 @@ func castValue(s string, t ArgType) (interface{}, error) {
 	case Bool:
 		return strconv.ParseBool(s)
 	default:
-		return nil, fmt.Errorf("unsupported type: %s", t)
+		return nil, &ArgumentParsingError{
+			fmt.Sprintf("unsupported type: %s", t),
+		}
 	}
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Introduces custom error types for argument parsing and casting

- Adds support for `--` (double dash) optional arguments in patterns

- Implements `without --` single-dash optional arguments via `=` prefix

- Replaces generic `fmt.Errorf` with structured `ArgumentParsingError`

- Updates example to demonstrate new optional argument syntax


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Pattern Parser"] -->|"Parses {==flag:type}"| B["Double-dash Flag"]
  A -->|"Parses {=flag:type}"| C["Single-dash Flag"]
  D["Error Handling"] -->|"Uses ArgumentParsingError"| E["Structured Errors"]
  B -->|"Flag: --flag"| F["Argument Pattern"]
  C -->|"Flag: flag"| F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>error.go</strong><dd><code>Custom error types for argument handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

error.go

<ul><li>Introduces <code>ArgumentParsingError</code> struct with <code>Message</code> field<br> <li> Introduces <code>ArgumentCastingError</code> struct for type casting failures<br> <li> Implements <code>Error()</code> method for <code>ArgumentParsingError</code> interface <br>compliance</ul>


</details>


  </td>
  <td><a href="https://github.com/n3tw0rth/vanda/pull/5/files#diff-097efd4fdcfbc4644e1d6fd6b758f217ca51969e14309c8b70d42a6e41dde579">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pattern.go</strong><dd><code>Implement double-dash and single-dash flag parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pattern.go

<ul><li>Replaces all <code>fmt.Errorf</code> calls with <code>ArgumentParsingError</code> instances<br> <li> Adds logic to distinguish between <code>==</code> (double-dash) and <code>=</code> (single-dash) <br>optional arguments<br> <li> Uses <code>strings.CutPrefix</code> for cleaner prefix handling<br> <li> Adds debug <code>println</code> statements for flag prefix detection<br> <li> Refactors optional argument parsing to support both flag formats</ul>


</details>


  </td>
  <td><a href="https://github.com/n3tw0rth/vanda/pull/5/files#diff-3e4a53063289aad17ef0aacd20074a0be29227cd60976239c7692f606da59574">+42/-25</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>vanda.go</strong><dd><code>Update error handling and flag matching logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

vanda.go

<ul><li>Replaces <code>map[string]interface{}</code> with <code>map[string]any</code> for Go 1.18+ <br>compatibility<br> <li> Converts all <code>fmt.Errorf</code> calls to <code>ArgumentParsingError</code> instances<br> <li> Updates flag matching logic to use <code>pat.Flag</code> field instead of hardcoded <br><code>-</code> prefix<br> <li> Maintains support for both flag formats in argument parsing loop</ul>


</details>


  </td>
  <td><a href="https://github.com/n3tw0rth/vanda/pull/5/files#diff-59ae636c5acc9e65dfacff66e0c7cd09ac5bb1362b7ac09c6fe7f60737140352">+18/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Update example with new flag syntax</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

example/main.go

<ul><li>Updates pattern to use new <code>==</code> (double-dash) and <code>=</code> (single-dash) syntax<br> <li> Changes example argv to demonstrate <code>--optionalone</code> and <code>optionaltwo</code> <br>arguments<br> <li> Simplifies pattern names from domain-specific to generic descriptors</ul>


</details>


  </td>
  <td><a href="https://github.com/n3tw0rth/vanda/pull/5/files#diff-1c171c5d51ba71728458fc771ff98395bcd3f59481e736c18e059372723acaab">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

